### PR TITLE
Ensure getScopeId function return value is int

### DIFF
--- a/Model/Indexer/DataHandler.php
+++ b/Model/Indexer/DataHandler.php
@@ -424,7 +424,7 @@ class DataHandler implements IndexerInterface
     private function getScopeId(array $dimensions) : int
     {
         $dimension = current($dimensions);
-        return $this->scopeResolver->getScope($dimension->getValue())->getId();
+        return (int)$this->scopeResolver->getScope($dimension->getValue())->getId();
     }
 
     /**


### PR DESCRIPTION
`ScopeResolver` said its `getId()` function returned an int... it lied.