### PR TITLE
Fix fatal error during validation when index table is empty

### DIFF
--- a/Model/Export/Validator/DeletedProductsValidator.php
+++ b/Model/Export/Validator/DeletedProductsValidator.php
@@ -45,6 +45,11 @@ class DeletedProductsValidator implements PreExportValidatorInterface
         $result = $connection->query($select);
         $row = $result->fetch();
 
+        // if no rows exist in the table, will be handled by min total products config during export
+        if (!$row) {
+            return;
+        }
+
         $maxDeletes = $this->sanityCheckConfig->getMaxDeleteProducts();
         if ($row['product_count'] > $maxDeletes) {
             throw new ValidationException(


### PR DESCRIPTION
With no rows, `$result->fetch()` returns `false`, which causes an error when `$row['product_count']` is checked