### PR TITLE
Add the ability to define custom attributes as being at product or variant level

### DIFF
--- a/Helper/AttributeConfig.php
+++ b/Helper/AttributeConfig.php
@@ -33,16 +33,23 @@ class AttributeConfig extends GeneralConfig
     private array $eavAttributesByType;
     private array $siteVariantAttributes;
 
+    private array $productLevelCustomAttributeCodes;
+    private array $variantLevelCustomAttributeCodes;
+
     public function __construct(
         Context $context,
         Resolver $localeResolver,
         StoreManagerInterface $storeManager,
         Json $json,
-        DataProvider $dataProvider
+        DataProvider $dataProvider,
+        array $productLevelCustomAttributeCodes = [],
+        array $variantLevelCustomAttributeCodes = []
     ) {
         parent::__construct($context, $localeResolver, $storeManager);
         $this->json = $json;
         $this->dataProvider = $dataProvider;
+        $this->productLevelCustomAttributeCodes = $productLevelCustomAttributeCodes;
+        $this->variantLevelCustomAttributeCodes = $variantLevelCustomAttributeCodes;
     }
 
     /**
@@ -113,9 +120,10 @@ class AttributeConfig extends GeneralConfig
     }
 
     /**
+     * @param bool $includeCustom Include custom-defined attributes in array
      * @return string[]
      */
-    public function getProductAttributeCodes(): array
+    public function getProductAttributeCodes(bool $includeCustom = false): array
     {
         if (!isset($this->productAttributeCodes)) {
             $attributeCodes = [];
@@ -124,13 +132,17 @@ class AttributeConfig extends GeneralConfig
             }
             $this->productAttributeCodes = $attributeCodes;
         }
+        if ($includeCustom) {
+            return array_merge($this->productAttributeCodes, $this->productLevelCustomAttributeCodes);
+        }
         return $this->productAttributeCodes;
     }
 
     /**
+     * @param bool $includeCustom Include custom-defined attributes in array
      * @return string[]
      */
-    public function getVariantAttributeCodes(): array
+    public function getVariantAttributeCodes(bool $includeCustom = false): array
     {
         if (!isset($this->variantAttributeCodes)) {
             $attributeCodes = [];
@@ -138,6 +150,9 @@ class AttributeConfig extends GeneralConfig
                 $attributeCodes[] = $attributeConfig['attribute'];
             }
             $this->variantAttributeCodes = $attributeCodes;
+        }
+        if ($includeCustom) {
+            return array_merge($this->variantAttributeCodes, $this->variantLevelCustomAttributeCodes);
         }
         return $this->variantAttributeCodes;
     }

--- a/Model/Indexer/DataHandler.php
+++ b/Model/Indexer/DataHandler.php
@@ -145,7 +145,7 @@ class DataHandler implements IndexerInterface
     private function processVariants(array &$documents)
     {
         $productAttributeCodes = [];
-        foreach ($this->attributeConfig->getProductAttributeCodes() as $code) {
+        foreach ($this->attributeConfig->getProductAttributeCodes(true) as $code) {
             $productAttributeCodes[$code] = true;
         }
         foreach ($documents as $productId => &$data) {
@@ -158,7 +158,7 @@ class DataHandler implements IndexerInterface
 
             // remove any variant-level attributes from parent product, ensuring it is set on each variant
             foreach ($data['product'] as $attributeCode => $productData) {
-                if (in_array($attributeCode, $this->attributeConfig->getVariantAttributeCodes())) {
+                if (in_array($attributeCode, $this->attributeConfig->getVariantAttributeCodes(true))) {
                     foreach ($data['variants'] as &$variantData) {
                         $variantData[$attributeCode] = $variantData[$attributeCode] ?? $productData;
                     }
@@ -183,7 +183,7 @@ class DataHandler implements IndexerInterface
             // remove product-level attributes from variants
             foreach ($data['variants'] as &$variantData) {
                 foreach ($variantData as $attributeCode => $attributeValue) {
-                    if (!in_array($attributeCode, $this->attributeConfig->getVariantAttributeCodes())) {
+                    if (!in_array($attributeCode, $this->attributeConfig->getVariantAttributeCodes(true))) {
                         unset($variantData[$attributeCode]);
                     }
                 }
@@ -202,7 +202,7 @@ class DataHandler implements IndexerInterface
         // keep them at variant level also - variant data won't be sent, but can be used to trigger resending
         // of parent data
         foreach ($documents as &$data) {
-            foreach ($this->attributeConfig->getVariantAttributeCodes() as $variantAttributeCode) {
+            foreach ($this->attributeConfig->getVariantAttributeCodes(true) as $variantAttributeCode) {
                 $this->processProductVariantAttribute($data, $variantAttributeCode);
             }
         }


### PR DESCRIPTION
Attributes need to be sent at either product or variant level, not both.
When we are providing custom attributes (i.e. not actual product attributes) via field providers, etc. we need to be able to say which level the attribute should be at.