### PR TITLE
Ensure root category is included in category collection

### DIFF
--- a/Model/RelevantCategory.php
+++ b/Model/RelevantCategory.php
@@ -68,6 +68,11 @@ class RelevantCategory
         if (count($ancestorIds) > 0) {
             $categories->addAttributeToFilter('entity_id', ['nin' => $ancestorIds]);
         }
+
+        // ensure the root category is in the collection
+        $categoryIds = array_merge($categories->getAllIds(),[$this->config->getRootCategoryId()]);
+        $categories = $this->categoryCollectionFactory->create();
+        $categories->addIdFilter($categoryIds);
         $categories->addNameToResult();
         return $categories;
     }


### PR DESCRIPTION
If the configured root category is the "actual" root category in Magento (entity_id 1), it will be excluded by the `is_active` filter.
This change adds the root category id to the list of active category ids and then applies an id filter.