### PR TITLE
Check specifically-defined attribute types before partial matches

### DIFF
--- a/Model/Export/Data/Products.php
+++ b/Model/Export/Data/Products.php
@@ -316,6 +316,12 @@ class Products
         if ($attributeCode === 'categories') {
             return FHAttributeTypes::ATTRIBUTE_TYPE_HIERARCHICAL;
         }
+        // check metadata configuration for custom attributes
+        foreach ($this->metaData->getCustomAttributeData() as $attributeData) {
+            if ($attributeData['attribute_code'] === $attributeCode) {
+                return $attributeData['fredhopper_type'];
+            }
+        }
         // all price attributes are floats
         if (strpos($attributeCode, 'price') !== false) {
             return FHAttributeTypes::ATTRIBUTE_TYPE_FLOAT;
@@ -328,12 +334,6 @@ class Products
         // all url attributes are assets
         if (strpos($attributeCode, 'url') !== false) {
             return FHAttributeTypes::ATTRIBUTE_TYPE_ASSET;
-        }
-        // check metadata configuration for custom attributes
-        foreach ($this->metaData->getCustomAttributeData() as $attributeData) {
-            if ($attributeData['attribute_code'] === $attributeCode) {
-                return $attributeData['fredhopper_type'];
-            }
         }
         return $this->attributeConfig->getAttributesWithFredhopperType()[$attributeCode] ?? false;
     }


### PR DESCRIPTION
If there are custom attributes with `price` in their attribute id (for example), it will return a type of `float`, meaning that the locale will not be set. However, in some cases, there may be a formatted price with a type of `set` or `list` that does require the locale to be set.

So, check the defined types from custom attributes before any pattern-matching.