### PR TITLE
Fix resolution of default locale value

### DIFF
--- a/Helper/GeneralConfig.php
+++ b/Helper/GeneralConfig.php
@@ -151,7 +151,7 @@ class GeneralConfig extends AbstractHelper
     {
         if (!isset($this->defaultLocale)) {
             $this->localeResolver->emulate($this->getDefaultStore());
-            $this->defaultLocale = $this->localeResolver->getDefaultLocale();
+            $this->defaultLocale = $this->localeResolver->getLocale();
             $this->localeResolver->revert();
         }
         return $this->defaultLocale;


### PR DESCRIPTION
When emulating using `LocaleResolver`, it replaces the `locale` value, not `defaultLocale`