### PR TITLE
Feature/exclude stores

### DIFF
--- a/Helper/GeneralConfig.php
+++ b/Helper/GeneralConfig.php
@@ -146,6 +146,9 @@ class GeneralConfig extends AbstractHelper
         return $this->defaultStore;
     }
 
+    /**
+     * @return array
+     */
     public function getExcludedStores(): array
     {
         if (!isset($this->excludedStores)) {

--- a/Helper/GeneralConfig.php
+++ b/Helper/GeneralConfig.php
@@ -22,6 +22,7 @@ class GeneralConfig extends AbstractHelper
     public const XML_PATH_VARIANT_PREFIX = self::XML_PATH_PREFIX . 'variant_prefix';
     public const XML_PATH_USE_SITE_VARIANT = self::XML_PATH_PREFIX . 'use_site_variant';
     public const XML_PATH_DEFAULT_STORE = self::XML_PATH_PREFIX . 'default_store';
+    public const XML_PATH_EXCLUDED_STORES = self::XML_PATH_PREFIX . 'excluded_stores';
     public const XML_PATH_SITE_VARIANT = self::XML_PATH_PREFIX . 'site_variant';
     public const XML_PATH_ROOT_CATEGORY = self::XML_PATH_PREFIX . 'root_category';
     public const XML_PATH_DEBUG_LOGGING = self::XML_PATH_PREFIX . 'debug_logging';
@@ -37,6 +38,7 @@ class GeneralConfig extends AbstractHelper
     private string $variantPrefix;
     private bool $useSiteVariant;
     private int $defaultStore;
+    private array $excludedStores;
     private string $defaultLocale;
     private int $rootCategoryId;
     private bool $debugLogging;
@@ -144,6 +146,15 @@ class GeneralConfig extends AbstractHelper
         return $this->defaultStore;
     }
 
+    public function getExcludedStores(): array
+    {
+        if (!isset($this->excludedStores)) {
+            $configValue = (string)$this->scopeConfig->getValue((self::XML_PATH_EXCLUDED_STORES));
+            $this->excludedStores = explode(',', $configValue);
+        }
+        return $this->excludedStores;
+    }
+
     /**
      * @return string
      */
@@ -184,6 +195,9 @@ class GeneralConfig extends AbstractHelper
                 $this->allSiteVariantSuffixes = ['']; // single empty string, rather than empty array
             } else {
                 foreach ($this->storeManager->getStores() as $store) {
+                    if (in_array($store->getId(), $this->getExcludedStores())) {
+                        continue;
+                    }
                     $this->allSiteVariantSuffixes[] = '_' . $this->getSiteVariant((int)$store->getId());
                 }
             }

--- a/Model/Indexer/Data/FredhopperDataProvider.php
+++ b/Model/Indexer/Data/FredhopperDataProvider.php
@@ -50,6 +50,10 @@ class FredhopperDataProvider
     {
         // ensure store id is an integer
         $storeId = (int)$storeId;
+        // check if store is excluded from indexing
+        if (in_array($storeId, $this->attributeConfig->getExcludedStores())) {
+            return;
+        }
         if ($productIds !== null) {
             $productIds = array_unique($productIds);
         }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -39,6 +39,11 @@
                     <comment>Store to be used for attributes that are not site-specific</comment>
                     <source_model>Magento\Config\Model\Config\Source\Store</source_model>
                 </field>
+                <field id="excluded_stores" translate="label comment" type="multiselect" sortOrder="105" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Excluded Stores</label>
+                    <comment>Stores to be excluded when generating export data</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Store</source_model>
+                </field>
                 <field id="root_category" translate="label comment" type="select" sortOrder="110" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Root category</label>
                     <comment>Subcategories are sent to Fredhopper</comment>


### PR DESCRIPTION
In some setups, there may be multiple store views per site variant (e.g. regular store and endless aisle, multiple locales, etc.)

With the current code, this leads to a couple of issues:

1. Attributes get repeated due to the `getAllSiteVariantSuffixes` function, adding the same site variant for multiple stores.
2. Data is indexed against stores when it's not needed, resulting in poorer performance.

This adds functionality to exclude stores from both the indexing and export (specifically the aforementioned functionality getting suffixes).

In theory it would be possible for someone to exclude the store that they've configured to be the default, but I don't think we need to handle that scenario - it's a simple config change to fix it.