### PR TITLE
Fix/site variant custom attributes

### DIFF
--- a/Helper/AttributeConfig.php
+++ b/Helper/AttributeConfig.php
@@ -19,6 +19,7 @@ class AttributeConfig extends GeneralConfig
 
     private Json $json;
     private DataProvider $dataProvider;
+    private CustomAttributeConfig $customAttributeConfig;
 
     private bool $useVariantProducts;
     private array $productAttributes;
@@ -33,23 +34,18 @@ class AttributeConfig extends GeneralConfig
     private array $eavAttributesByType;
     private array $siteVariantAttributes;
 
-    private array $productLevelCustomAttributeCodes;
-    private array $variantLevelCustomAttributeCodes;
-
     public function __construct(
         Context $context,
         Resolver $localeResolver,
         StoreManagerInterface $storeManager,
         Json $json,
         DataProvider $dataProvider,
-        array $productLevelCustomAttributeCodes = [],
-        array $variantLevelCustomAttributeCodes = []
+        CustomAttributeConfig $customAttributeConfig
     ) {
         parent::__construct($context, $localeResolver, $storeManager);
         $this->json = $json;
         $this->dataProvider = $dataProvider;
-        $this->productLevelCustomAttributeCodes = $productLevelCustomAttributeCodes;
-        $this->variantLevelCustomAttributeCodes = $variantLevelCustomAttributeCodes;
+        $this->customAttributeConfig = $customAttributeConfig;
     }
 
     /**
@@ -133,7 +129,10 @@ class AttributeConfig extends GeneralConfig
             $this->productAttributeCodes = $attributeCodes;
         }
         if ($includeCustom) {
-            return array_merge($this->productAttributeCodes, $this->productLevelCustomAttributeCodes);
+            return array_merge(
+                $this->productAttributeCodes,
+                $this->customAttributeConfig->getProductLevelCustomAttributes()
+            );
         }
         return $this->productAttributeCodes;
     }
@@ -152,7 +151,10 @@ class AttributeConfig extends GeneralConfig
             $this->variantAttributeCodes = $attributeCodes;
         }
         if ($includeCustom) {
-            return array_merge($this->variantAttributeCodes, $this->variantLevelCustomAttributeCodes);
+            return array_merge(
+                $this->variantAttributeCodes,
+                $this->customAttributeConfig->getVariantLevelCustomAttributes()
+            );
         }
         return $this->variantAttributeCodes;
     }

--- a/Helper/CustomAttributeConfig.php
+++ b/Helper/CustomAttributeConfig.php
@@ -10,11 +10,15 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class CustomAttributeConfig extends GeneralConfig
 {
+    private const ATTRIBUTE_LEVEL_PRODUCT = 'product';
+    private const ATTRIBUTE_LEVEL_VARIANT = 'variant';
 
     /** @var array */
     private array $customAttributeData;
     /** string[] */
     private array $siteVariantCustomAttributes;
+    private array $productLevelCustomAttributeCodes;
+    private array $variantLevelCustomAttributeCodes;
 
     public function __construct(
         Context $context,
@@ -46,5 +50,39 @@ class CustomAttributeConfig extends GeneralConfig
             }
         }
         return $this->siteVariantCustomAttributes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProductLevelCustomAttributes(): array
+    {
+        if (!isset($this->productLevelCustomAttributeCodes)) {
+            $this->productLevelCustomAttributeCodes = [];
+            foreach ($this->customAttributeData as $attributeCode => $attributeData) {
+                $attributeLevel = $attributeData['level'] ?? self::ATTRIBUTE_LEVEL_PRODUCT;
+                if ($attributeLevel === self::ATTRIBUTE_LEVEL_PRODUCT) {
+                    $this->productLevelCustomAttributeCodes[] = $attributeCode;
+                }
+            }
+        }
+        return $this->productLevelCustomAttributeCodes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getVariantLevelCustomAttributes(): array
+    {
+        if (!isset($this->variantLevelCustomAttributeCodes)) {
+            $this->variantLevelCustomAttributeCodes = [];
+            foreach ($this->customAttributeData as $attributeCode => $attributeData) {
+                $attributeLevel = $attributeData['level'] ?? self::ATTRIBUTE_LEVEL_PRODUCT;
+                if ($attributeLevel === self::ATTRIBUTE_LEVEL_VARIANT) {
+                    $this->variantLevelCustomAttributeCodes[] = $attributeCode;
+                }
+            }
+        }
+        return $this->variantLevelCustomAttributeCodes;
     }
 }

--- a/Helper/CustomAttributeConfig.php
+++ b/Helper/CustomAttributeConfig.php
@@ -40,7 +40,7 @@ class CustomAttributeConfig extends GeneralConfig
         if (!isset($this->siteVariantCustomAttributes)) {
             $this->siteVariantCustomAttributes = [];
             foreach ($this->customAttributeData as $attributeCode => $attributeData) {
-                if ($attributeData['is_site_variant']) {
+                if ($attributeData['is_site_variant'] ?? false) {
                     $this->siteVariantCustomAttributes[] = $attributeCode;
                 }
             }

--- a/Helper/CustomAttributeConfig.php
+++ b/Helper/CustomAttributeConfig.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aligent\FredhopperIndexer\Helper;
+
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Locale\Resolver;
+use Magento\Store\Model\StoreManagerInterface;
+
+class CustomAttributeConfig extends GeneralConfig
+{
+
+    /** @var array */
+    private array $customAttributeData;
+    /** string[] */
+    private array $siteVariantCustomAttributes;
+
+    public function __construct(
+        Context $context,
+        Resolver $localeResolver,
+        StoreManagerInterface $storeManager,
+        array $customAttributeData
+    ) {
+        parent::__construct($context, $localeResolver, $storeManager);
+
+        $this->customAttributeData = $customAttributeData;
+    }
+
+    public function getCustomAttributeData(): array
+    {
+        return $this->customAttributeData;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSiteVariantCustomAttributes(): array
+    {
+        if (!isset($this->siteVariantCustomAttributes)) {
+            $this->siteVariantCustomAttributes = [];
+            foreach ($this->customAttributeData as $attributeCode => $attributeData) {
+                if ($attributeData['is_site_variant']) {
+                    $this->siteVariantCustomAttributes[] = $attributeCode;
+                }
+            }
+        }
+        return $this->siteVariantCustomAttributes;
+    }
+}

--- a/Model/Export/Data/Meta.php
+++ b/Model/Export/Data/Meta.php
@@ -7,6 +7,7 @@ namespace Aligent\FredhopperIndexer\Model\Export\Data;
 use Aligent\FredhopperIndexer\Block\Adminhtml\Form\Field\FHAttributeTypes;
 use Aligent\FredhopperIndexer\Helper\AgeAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\AttributeConfig;
+use Aligent\FredhopperIndexer\Helper\CustomAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\ImageAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\PricingAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\StockAttributeConfig;
@@ -28,7 +29,7 @@ class Meta
     private StockAttributeConfig $stockAttributeConfig;
     private AgeAttributeConfig $ageAttributeConfig;
     private ImageAttributeConfig $imageAttributeConfig;
-    private array $customAttributeData;
+    private CustomAttributeConfig $customAttributeConfig;
 
     private int $rootCategoryId = 1;
 
@@ -41,7 +42,7 @@ class Meta
         StockAttributeConfig $stockAttributeConfig,
         AgeAttributeConfig $ageAttributeConfig,
         ImageAttributeConfig $imageAttributeConfig,
-        $customAttributeData = []
+        CustomAttributeConfig $customAttributeConfig
     ) {
         $this->relevantCategory = $relevantCategory;
         $this->customerGroupRepository = $customerGroupRepository;
@@ -50,8 +51,8 @@ class Meta
         $this->pricingAttributeConfig = $pricingAttributeConfig;
         $this->stockAttributeConfig = $stockAttributeConfig;
         $this->ageAttributeConfig = $ageAttributeConfig;
-        $this->customAttributeData = $customAttributeData;
         $this->imageAttributeConfig = $imageAttributeConfig;
+        $this->customAttributeConfig = $customAttributeConfig;
     }
 
     /**
@@ -165,8 +166,8 @@ class Meta
             $priceAttributes['max_price'] = 'Maximum Price';
         }
         // check for any custom attributes that are prices
-        foreach ($this->customAttributeData as $attributeCode => $attributeData) {
-            if (($attributeData['fredhopper_type'] ?? null) === 'price') {
+        foreach ($this->customAttributeConfig->getCustomAttributeData() as $attributeCode => $attributeData) {
+            if (($attributeData['type'] ?? null) === 'price') {
                 $priceAttributes[$attributeCode] = $attributeData['label'];
             }
         }
@@ -217,7 +218,7 @@ class Meta
             $stockAttributes['stock_status'] = 'Stock Status';
         }
         // check for any custom stock attributes
-        foreach ($this->customAttributeData as $attributeCode => $attributeData) {
+        foreach ($this->customAttributeConfig->getCustomAttributeData() as $attributeCode => $attributeData) {
             if (($attributeData['type'] ?? null) === 'stock') {
                 $stockAttributes[$attributeCode] = $attributeData['label'];
             }
@@ -255,7 +256,7 @@ class Meta
             '_thumburl' => 'Thumbnail URL'
         ];
         // check for custom image attributes
-        foreach ($this->customAttributeData as $attributeCode => $attributeData) {
+        foreach ($this->customAttributeConfig->getCustomAttributeData() as $attributeCode => $attributeData) {
             if (($attributeData['type'] ?? null) === 'image') {
                 $imageAttributes[$attributeCode] = $attributeData['label'];
             }
@@ -321,21 +322,38 @@ class Meta
     private function getCustomAttributesArray(string $defaultLocale): array
     {
         $attributesArray = [];
-        foreach ($this->customAttributeData as $customAttribute) {
+        $siteVariantSuffixes = $this->attributeConfig->getAllSiteVariantSuffixes();
+        foreach ($this->customAttributeConfig->getCustomAttributeData() as $customAttribute) {
             // check if attribute has already been processed as price/stock/image attribute
             if (!empty($customAttribute['type'])) {
                 continue;
             }
-            $attributesArray[] = [
-                'attribute_id' => $customAttribute['attribute_code'],
-                'type' => $customAttribute['fredhopper_type'],
-                'names' => [
-                    [
-                        'locale' => $defaultLocale,
-                        'name' => __($customAttribute['label'])
+
+            if ($customAttribute['is_site_variant']) {
+                foreach ($siteVariantSuffixes as $siteVariantSuffix) {
+                    $attributesArray[] = [
+                        'attribute_id' => $customAttribute['attribute_code'] . $siteVariantSuffix,
+                        'type' => $customAttribute['fredhopper_type'],
+                        'names' => [
+                            [
+                                'locale' => $defaultLocale,
+                                'name' => __($customAttribute['label'])
+                            ]
+                        ]
+                    ];
+                }
+            } else {
+                $attributesArray[] = [
+                    'attribute_id' => $customAttribute['attribute_code'],
+                    'type' => $customAttribute['fredhopper_type'],
+                    'names' => [
+                        [
+                            'locale' => $defaultLocale,
+                            'name' => __($customAttribute['label'])
+                        ]
                     ]
-                ]
-            ];
+                ];
+            }
         }
         return $attributesArray;
     }
@@ -397,13 +415,5 @@ class Meta
             $categoryData['children'] = $childArray;
         }
         return $categoryData;
-    }
-
-    /**
-     * @return array
-     */
-    public function getCustomAttributeData(): array
-    {
-        return $this->customAttributeData;
     }
 }

--- a/Model/Export/Data/Meta.php
+++ b/Model/Export/Data/Meta.php
@@ -329,7 +329,7 @@ class Meta
                 continue;
             }
 
-            if ($customAttribute['is_site_variant']) {
+            if ($customAttribute['is_site_variant'] ?? false) {
                 foreach ($siteVariantSuffixes as $siteVariantSuffix) {
                     $attributesArray[] = [
                         'attribute_id' => $customAttribute['attribute_code'] . $siteVariantSuffix,

--- a/Model/Export/Data/Products.php
+++ b/Model/Export/Data/Products.php
@@ -7,6 +7,7 @@ namespace Aligent\FredhopperIndexer\Model\Export\Data;
 use Aligent\FredhopperIndexer\Block\Adminhtml\Form\Field\FHAttributeTypes;
 use Aligent\FredhopperIndexer\Helper\AgeAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\AttributeConfig;
+use Aligent\FredhopperIndexer\Helper\CustomAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\GeneralConfig;
 use Aligent\FredhopperIndexer\Helper\PricingAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\StockAttributeConfig;
@@ -36,6 +37,7 @@ class Products
     private PricingAttributeConfig $pricingAttributeConfig;
     private StockAttributeConfig $stockAttributeConfig;
     private AgeAttributeConfig $ageAttributeConfig;
+    private CustomAttributeConfig $customAttributeConfig;
     private Meta $metaData;
     private Json $json;
     private ResourceConnection $resource;
@@ -69,10 +71,6 @@ class Products
         'is_new',
         'days_online'
     ];
-    /**
-     * @var string[]
-     */
-    private array $siteVariantCustomAttributes = [];
 
     public function __construct(
         GeneralConfig $generalConfig,
@@ -80,20 +78,21 @@ class Products
         PricingAttributeConfig $pricingAttributeConfig,
         StockAttributeConfig $stockAttributeConfig,
         AgeAttributeConfig $ageAttributeConfig,
+        CustomAttributeConfig $customAttributeConfig,
         Meta $metaData,
         Json $json,
         ResourceConnection $resource,
         $siteVariantPriceAttributes = [],
         $siteVariantStockAttributes = [],
         $siteVariantImageAttributes = [],
-        $siteVariantAgeAttributes = [],
-        $siteVariantCustomAttributes = []
+        $siteVariantAgeAttributes = []
     ) {
         $this->generalConfig = $generalConfig;
         $this->attributeConfig = $attributeConfig;
         $this->pricingAttributeConfig = $pricingAttributeConfig;
         $this->stockAttributeConfig = $stockAttributeConfig;
         $this->ageAttributeConfig = $ageAttributeConfig;
+        $this->customAttributeConfig = $customAttributeConfig;
         $this->metaData = $metaData;
         $this->json = $json;
         $this->resource = $resource;
@@ -106,8 +105,6 @@ class Products
             array_merge($this->siteVariantImageAttributes, $siteVariantImageAttributes) : [];
         $this->siteVariantAgeAttributes = $this->ageAttributeConfig->getUseSiteVariant() ?
             array_merge($this->siteVariantAgeAttributes, $siteVariantAgeAttributes) : [];
-        $this->siteVariantCustomAttributes = $this->generalConfig->getUseSiteVariant() ?
-            array_merge($this->siteVariantCustomAttributes, $siteVariantCustomAttributes) : [];
     }
 
     /**
@@ -316,8 +313,8 @@ class Products
         if ($attributeCode === 'categories') {
             return FHAttributeTypes::ATTRIBUTE_TYPE_HIERARCHICAL;
         }
-        // check metadata configuration for custom attributes
-        foreach ($this->metaData->getCustomAttributeData() as $attributeData) {
+        // check custom attribute configuration
+        foreach ($this->customAttributeConfig->getCustomAttributeData() as $attributeData) {
             if ($attributeData['attribute_code'] === $attributeCode) {
                 return $attributeData['fredhopper_type'];
             }
@@ -355,7 +352,7 @@ class Products
                 in_array($attributeCode, $this->siteVariantStockAttributes) ||
                 in_array($attributeCode, $this->siteVariantImageAttributes) ||
                 in_array($attributeCode, $this->siteVariantAgeAttributes) ||
-                in_array($attributeCode, $this->siteVariantCustomAttributes) ||
+                in_array($attributeCode, $this->customAttributeConfig->getSiteVariantCustomAttributes()) ||
                 $this->isSiteVariantPriceAttribute($attributeCode)) {
                 return "{$attributeCode}_$siteVariant";
             }


### PR DESCRIPTION
This would be a new major version due to backwards-incompatibility.

Point is to fix a couple of issues, but also move custom attribute configuration to a single class, rather that it being present in 2 or 3. Additionally, all custom attribute configuration is now done through the single `customAttributeData` argument, rather than having separate arguments for site variants, product level, etc.