### PR TITLE
Use isset check for directory initialization

### DIFF
--- a/Model/Export/IncrementalExporter.php
+++ b/Model/Export/IncrementalExporter.php
@@ -70,7 +70,7 @@ class IncrementalExporter extends AbstractProductExporter
      */
     protected function getDirectory(): string
     {
-        if (!$this->directory) {
+        if (!isset($this->directory)) {
             $this->directory = '/tmp/fh_export_incremental_' . time();
         }
         return $this->directory;


### PR DESCRIPTION
Property is typed, so have to use `isset`, rather than just "truthyness".
This is already fixed in the full exporter