### PR TITLE
Ensure array keys are retained for multi-select attributes

### DIFF
--- a/Model/Indexer/Data/ProductMapper.php
+++ b/Model/Indexer/Data/ProductMapper.php
@@ -237,8 +237,8 @@ class ProductMapper
     private function prepareMultiselectValues(array $values): array
     {
         $multiSelectValues = [];
-        foreach ($values as $value) {
-            $multiSelectValues[] = explode(',', $value);
+        foreach ($values as $key => $value) {
+            $multiSelectValues[$key] = explode(',', $value);
         }
         return $multiSelectValues;
     }


### PR DESCRIPTION
Fixes a bug introduced when converting discouraged functions (in this case, `array_map`)