### PR TITLE
Ensure all values are quoted regardless of type

### DIFF
--- a/Model/Export/Data/Products.php
+++ b/Model/Export/Data/Products.php
@@ -280,7 +280,7 @@ class Products
                 $values = [];
                 foreach ($attributeValues as $value) {
                     $valueEntry = [
-                        'value' => $value
+                        'value' => (string)$value // ensure all values are strings
                     ];
                     if ($addLocale) {
                         $valueEntry['locale'] = $defaultLocale;


### PR DESCRIPTION
Per advice from Attraqt, all values need to be sent enclosed in quotes.