### PR TITLE
Fix/multi store

### DIFF
--- a/Model/Export/Data/Products.php
+++ b/Model/Export/Data/Products.php
@@ -262,9 +262,15 @@ class Products
         string $defaultLocale
     ): array {
         $attributes = [];
+        $categories = [];
         foreach ($productData['stores'] as $storeId => $storeData) {
             // convert to correct format for fredhopper export
             foreach ($storeData as $attributeCode => $attributeValues) {
+                // handle categories separately
+                if ($attributeCode === 'categories') {
+                    $categories[] = $attributeValues;
+                    continue;
+                }
                 if (!is_array($attributeValues)) {
                     $attributeValues = [$attributeValues];
                 }
@@ -277,7 +283,6 @@ class Products
                     case FHAttributeTypes::ATTRIBUTE_TYPE_SET:
                     case FHAttributeTypes::ATTRIBUTE_TYPE_SET64:
                     case FHAttributeTypes::ATTRIBUTE_TYPE_ASSET:
-                    case FHAttributeTypes::ATTRIBUTE_TYPE_HIERARCHICAL:
                         // add locale to attribute data
                         $addLocale = true;
                         break;
@@ -313,6 +318,19 @@ class Products
                 }
             }
         }
+        // collate categories from all stores
+        $categories = array_unique(array_merge(...$categories));
+        $categoryValues = [];
+        foreach ($categories as $category) {
+            $categoryValues[] = [
+                'value' => (string)$category,
+                'locale' => $defaultLocale
+            ];
+        }
+        $attributes[] = [
+            'attribute_id' => 'categories',
+            'values' => $categoryValues
+        ];
         return $attributes;
     }
 


### PR DESCRIPTION
Better handling for multi-store setups where products may only belong to a subset of stores:

- Previously, if an attribute was not marked as being site variant, then the attribute would get its value from the configured "default" store.
- If a product did not belong to the default store, all such attributes would be omitted.
- Now, the "default store" is determined on a product-by-product basis, with the configured default having precedence
   - Otherwise, it will use the first store that has an entry for the product
- Additionally, categories are complicated, as stores may have different categories assigned.
   - Since the "categories" attribute in FH cannot be made to use a site variant, we need to collate categories from all stores, rather than from a default store.