### PR TITLE
Only include categories that belong to the store being indexed

### DIFF
--- a/Model/Indexer/Data/CategoryFieldsProvider.php
+++ b/Model/Indexer/Data/CategoryFieldsProvider.php
@@ -9,6 +9,9 @@ use Aligent\FredhopperIndexer\Model\Export\Data\Meta;
 use Aligent\FredhopperIndexer\Model\RelevantCategory;
 use Magento\AdvancedSearch\Model\Adapter\DataMapper\AdditionalFieldsProviderInterface;
 use Magento\AdvancedSearch\Model\ResourceModel\Index;
+use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
 
 class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
 {
@@ -16,27 +19,37 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
     private Index $index;
     private RelevantCategory $relevantCategory;
     private GeneralConfig $config;
+    private StoreManagerInterface $storeManager;
+    private CategoryResource $categoryResource;
+
     private int $rootCategoryId;
     /**
      * Array has form [int:category id => bool:allowed?]
      */
     private array $allowCategories;
+    private array $storeCategories = [];
 
     public function __construct(
         Index $index,
         RelevantCategory $relevantCategory,
-        GeneralConfig $config
+        GeneralConfig $config,
+        StoreManagerInterface $storeManager,
+        CategoryResource $categoryResource
     ) {
         $this->index = $index;
         $this->relevantCategory = $relevantCategory;
         $this->config = $config;
+        $this->storeManager = $storeManager;
+        $this->categoryResource = $categoryResource;
     }
 
     /**
      * @inheritDoc
+     * @throws NoSuchEntityException
      */
     public function getFields(array $productIds, $storeId): array
     {
+        // generate complete list of allowed categories based on the configured root category
         if (!isset($this->allowCategories)) {
             $this->rootCategoryId = $this->config->getRootCategoryId();
             $collection = $this->relevantCategory->getCollection();
@@ -45,6 +58,15 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
                 $allowCategories[$category->getId()] = true;
             }
             $this->allowCategories = $allowCategories;
+        }
+
+        // generate list of store categories
+        if (!isset($this->storeCategories[$storeId])) {
+            $storeGroupId = $this->storeManager->getStore($storeId)->getStoreGroupId();
+            $rootCategoryId = $this->storeManager->getGroup($storeGroupId)->getRootCategoryId();
+            // set recursion level high to ensure all categories are returned
+            $categoryNodes = $this->categoryResource->getCategories($rootCategoryId, 100, false, true);
+            $this->storeCategories[$storeId] = array_merge([$rootCategoryId], $categoryNodes->getAllIds());
         }
 
         $result = [];
@@ -59,9 +81,9 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
                 unset($categoryInfo[$this->rootCategoryId]);
             }
 
-            // Add to other relevant categories
+            // Add to other relevant categories, as long as the category is valid for the current store
             foreach ($categoryInfo as $catId => $position) {
-                if (isset($this->allowCategories[$catId])) {
+                if (isset($this->allowCategories[$catId]) && in_array($catId, $this->storeCategories[$storeId])) {
                     $result[$productId]['categories'][] = $catId;
                 }
             }


### PR DESCRIPTION
In a multi-store setup, each store may have a different root category, but all should fall under the configured root category for the indexer module.

If a product is assigned to categories for a store, but is not assigned to the store's website, or is disabled in the store, the category ids will still be returned, which means that the product will end up being returned by the `fas` requests to Fredhopper (as it is only based on category.

This change gets a list of valid category ids per store, and uses them as an additional check when adding category ids to products. If the category is not valid for the store being indexed, it won't be added.