### PR TITLE
Increase size of attribute_data column to cater for more data.

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -10,7 +10,7 @@
                 comment="Product ID"/>
         <column xsi:type="int" name="parent_id" padding="10" unsigned="true" nullable="true" identity="false"
                 comment="Parent Product ID"/>
-        <column xsi:type="text" name="attribute_data" nullable="false"
+        <column xsi:type="mediumtext" name="attribute_data" nullable="false"
                 comment="JSON-encoded attribute data to be sent to Fredhopper"/>
         <column xsi:type="varchar" name="operation_type" length="1" nullable="true"
                 comment="Operation Type (a=Add,u=Update,r=Replace,d=Delete)"/>


### PR DESCRIPTION
In certain circumstances (e.g. a product having upwards of 100 image URLs that need to be sent for some reason), the size of the attribute_data column can exceed the maximum of 65,535 characters.
By changing to `mediumtext`, the maximum size is increased to 16,777,215 characters, which should be safe enough (I hope!)

Worst case, we can increase it again, but sincerely hope that won't be necessary.