### PR TITLE
Prevent immediate export command from resetting index table

### DIFF
--- a/Model/Export/AbstractProductExporter.php
+++ b/Model/Export/AbstractProductExporter.php
@@ -58,7 +58,7 @@ abstract class AbstractProductExporter implements ExporterInterface
         File $filesystem,
         Json $json,
         LoggerInterface $logger,
-        $productLimit = 1000
+        int $productLimit = 1000
     ) {
         $this->products = $products;
         $this->meta = $meta;

--- a/Model/Export/Data/ImmediateProducts.php
+++ b/Model/Export/Data/ImmediateProducts.php
@@ -12,6 +12,7 @@ use Aligent\FredhopperIndexer\Helper\GeneralConfig;
 use Aligent\FredhopperIndexer\Helper\ImageAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\PricingAttributeConfig;
 use Aligent\FredhopperIndexer\Helper\StockAttributeConfig;
+use Aligent\FredhopperIndexer\Model\ResourceModel\Engine as FredhopperEngine;
 use Magento\Catalog\Model\ResourceModel\Product;
 use Magento\Store\Model\StoreDimensionProvider;
 use Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full;
@@ -28,37 +29,42 @@ class ImmediateProducts extends Products
     /**
      * @var array
      */
-    protected $skus = [];
+    protected array $skus = [];
 
     /**
      * @var StoreDimensionProvider
      */
-    protected $dimensionProvider;
+    protected StoreDimensionProvider $dimensionProvider;
 
     /**
      * @var Full
      */
-    protected $indexerAction;
+    protected Full $indexerAction;
 
     /**
      * @var EngineProvider
      */
-    protected $engineProvider;
+    protected EngineProvider $engineProvider;
 
     /**
      * @var DataHandlerFactory
      */
-    protected $dataHandlerFactory;
+    protected DataHandlerFactory $dataHandlerFactory;
 
     /**
      * @var Product
      */
-    protected $productResource;
+    protected Product $productResource;
 
     /**
      * @var ResourceConnection
      */
     private ResourceConnection $resource;
+
+    /**
+     * @var Json
+     */
+    private Json $json;
 
     /**
      * @param StoreDimensionProvider $dimensionProvider
@@ -122,6 +128,7 @@ class ImmediateProducts extends Products
             $siteVariantAgeAttributes
         );
         $this->resource = $resource;
+        $this->json = $json;
     }
 
     /**
@@ -144,7 +151,7 @@ class ImmediateProducts extends Products
     protected function getRawProductData(bool $isIncremental, bool $isVariants) : array
     {
         $engine = $this->engineProvider->get();
-        if (!($engine instanceof \Aligent\FredhopperIndexer\Model\ResourceModel\Engine)) {
+        if (!($engine instanceof FredhopperEngine)) {
             throw new \RuntimeException("Fredhopper is not configured as the search engine in Catalog Search");
         }
 
@@ -170,7 +177,7 @@ class ImmediateProducts extends Products
                         'product_type' => 'p',
                         'product_id' => $docKey,
                         'parent_id' => null,
-                        'attribute_data' => json_encode($doc['product']),
+                        'attribute_data' => $this->json->serialize($doc['product']),
                         'operation_type' => 'a',
                     ];
                     $products[] = $product;
@@ -184,7 +191,7 @@ class ImmediateProducts extends Products
                             'product_type' => 'v',
                             'product_id' => $variantKey,
                             'parent_id' => $docKey,
-                            'attribute_data' => json_encode($variant),
+                            'attribute_data' => $this->json->serialize($variant),
                             'operation_type' => 'a',
                         ];
                         $products[] = $product;

--- a/Model/Export/IncrementalExporter.php
+++ b/Model/Export/IncrementalExporter.php
@@ -18,6 +18,7 @@ class IncrementalExporter extends AbstractProductExporter
 {
 
     private DataHandler $dataHandler;
+    private bool $resetIndexTable;
 
     public function __construct(
         Data\Products $products,
@@ -31,7 +32,8 @@ class IncrementalExporter extends AbstractProductExporter
         Json $json,
         LoggerInterface $logger,
         DataHandler $dataHandler,
-        $productLimit = 1000
+        int $productLimit = 1000,
+        bool $resetIndexTable = true
     ) {
         parent::__construct(
             $products,
@@ -47,6 +49,7 @@ class IncrementalExporter extends AbstractProductExporter
             $productLimit
         );
         $this->dataHandler = $dataHandler;
+        $this->resetIndexTable = $resetIndexTable;
     }
 
     /**
@@ -58,7 +61,7 @@ class IncrementalExporter extends AbstractProductExporter
     {
         $this->logger->info('Performing incremental data export');
         $success = $this->doExport(true);
-        if ($success) {
+        if ($success && $this->resetIndexTable) {
             $success = $this->dataHandler->resetIndexAfterExport();
         }
         $this->logger->info('Incremental product export ' . ($success ? 'completed successfully' : 'failed'));

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -30,6 +30,7 @@
     <virtualType name="FredhopperImmediateExporter" type="Aligent\FredhopperIndexer\Model\Export\IncrementalExporter">
         <arguments>
             <argument name="products" xsi:type="object">Aligent\FredhopperIndexer\Model\Export\Data\ImmediateProducts</argument>
+            <argument name="resetIndexTable" xsi:type="boolean">false</argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
When an immediate export is run, the index table is not updated. If it's not a dry-run, the incremental exporter will clear all operation values from the table, as well as deleting records marked as being deleted.

This change ensures that the immediate export job never updates the database table.