### PR TITLE
Handle case when products have no prices in current website

### DIFF
--- a/Model/Indexer/Data/PriceFieldsProvider.php
+++ b/Model/Indexer/Data/PriceFieldsProvider.php
@@ -110,6 +110,6 @@ class PriceFieldsProvider implements AdditionalFieldsProviderInterface
             $result[$row['website_id']][$row['entity_id']][$row['customer_group_id']] = $prices;
         }
 
-        return $result[$websiteId];
+        return $result[$websiteId] ?? [];
     }
 }


### PR DESCRIPTION
In multi-site setup where not all products are available in all websites, an error can be thrown due to `$websiteId` array key being undefined. It shouldn't actually cause a problem, as it would go on to the next store, but it will end up putting a bunch of errors in log files.