### PR TITLE
Fix duplicated $this reference when generating variant files

### DIFF
--- a/Model/Export/AbstractProductExporter.php
+++ b/Model/Export/AbstractProductExporter.php
@@ -211,7 +211,7 @@ abstract class AbstractProductExporter implements ExporterInterface
             $fileIndex = 0;
             foreach (array_chunk($variantIds, $this->productLimit) as $ids) {
                 $variantData = $this->products->getVariantData($ids, $isIncremental);
-                if (!$this-$this->generateVariantsJson($variantData, $fileIndex)) {
+                if (!$this->generateVariantsJson($variantData, $fileIndex)) {
                     return false;
                 }
                 $fileIndex++;


### PR DESCRIPTION
Duplicated reference to `$this` results in the if condition being met, so only a single variants file is produced.