### PR TITLE
Ensure list of product ids is unique

### DIFF
--- a/Model/Export/Data/Products.php
+++ b/Model/Export/Data/Products.php
@@ -146,6 +146,7 @@ class Products
         } else {
             $select->where("ifnull(operation_type, '') <> 'd'");
         }
+        $select->distinct();
 
         return $connection->fetchCol($select);
     }


### PR DESCRIPTION
We can end up with the same product id from multiple stores, resulting in products appearing in multiple export files (and more export files than necessary being created).