### PR TITLE
Better handling of product ids for immediate product export

### DIFF
--- a/Model/Export/Data/ImmediateProducts.php
+++ b/Model/Export/Data/ImmediateProducts.php
@@ -144,14 +144,28 @@ class ImmediateProducts extends Products
     /**
      * @inheritDoc
      */
+    public function getAllProductIds(bool $isIncremental): array
+    {
+        return $this->productResource->getProductsIdsBySkus($this->skus);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAllVariantIds(bool $isIncremental): array
+    {
+        return $this->getAllProductIds($isIncremental);
+    }
+
+    /**
+     * @inheritDoc
+     */
     protected function getRawProductData(array $productIds, bool $isIncremental, bool $isVariants) : array
     {
         $engine = $this->engineProvider->get();
         if (!($engine instanceof FredhopperEngine)) {
             throw new \RuntimeException("Fredhopper is not configured as the search engine in Catalog Search");
         }
-
-        $productIds = $this->productResource->getProductsIdsBySkus($this->skus);
 
         /** @var DataHandler $dataHandler */
         $dataHandler = $this->dataHandlerFactory->create();


### PR DESCRIPTION
Due to changes with how product exports are handled (in order to resolve memory issues), product ids are retrieved beforehand and then looped through.
Without this change, all products in the table will be iterated over, potentially resulting in duplicate records. It will still only process the entered skus, but it may do so multiple times.

This change just overwrites the functions to get product and variant ids so that they use the entered skus only.