### PR TITLE
Avoid error when no email recipients are configured

### DIFF
--- a/Helper/SanityCheckConfig.php
+++ b/Helper/SanityCheckConfig.php
@@ -51,7 +51,7 @@ class SanityCheckConfig extends GeneralConfig
      */
     public function getErrorEmailRecipients(): array
     {
-        $rawConfig = $this->scopeConfig->getValue(self::XML_PATH_REPORT_EMAIL);
+        $rawConfig = $this->scopeConfig->getValue(self::XML_PATH_REPORT_EMAIL) ?? '';
         $emailRecipients = [];
         foreach (preg_split('/,\s*/', $rawConfig) as $recipient) {
             if (!empty($recipient)) {


### PR DESCRIPTION
If pre-export validation errors occur, it will attempt to send an email to all the configured recipients. If there is none configured, passing null to `preg_split` will cause an error.