### PR TITLE
Fix/allowed categories

### DIFF
--- a/Model/Indexer/Data/CategoryFieldsProvider.php
+++ b/Model/Indexer/Data/CategoryFieldsProvider.php
@@ -9,9 +9,7 @@ use Aligent\FredhopperIndexer\Model\Export\Data\Meta;
 use Aligent\FredhopperIndexer\Model\RelevantCategory;
 use Magento\AdvancedSearch\Model\Adapter\DataMapper\AdditionalFieldsProviderInterface;
 use Magento\AdvancedSearch\Model\ResourceModel\Index;
-use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\StoreManagerInterface;
 
 class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
 {
@@ -19,8 +17,6 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
     private Index $index;
     private RelevantCategory $relevantCategory;
     private GeneralConfig $config;
-    private StoreManagerInterface $storeManager;
-    private CategoryResource $categoryResource;
 
     private int $rootCategoryId;
     /**
@@ -32,15 +28,11 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
     public function __construct(
         Index $index,
         RelevantCategory $relevantCategory,
-        GeneralConfig $config,
-        StoreManagerInterface $storeManager,
-        CategoryResource $categoryResource
+        GeneralConfig $config
     ) {
         $this->index = $index;
         $this->relevantCategory = $relevantCategory;
         $this->config = $config;
-        $this->storeManager = $storeManager;
-        $this->categoryResource = $categoryResource;
     }
 
     /**
@@ -60,13 +52,10 @@ class CategoryFieldsProvider implements AdditionalFieldsProviderInterface
             $this->allowCategories = $allowCategories;
         }
 
-        // generate list of store categories
+        // get list of store categories
         if (!isset($this->storeCategories[$storeId])) {
-            $storeGroupId = $this->storeManager->getStore($storeId)->getStoreGroupId();
-            $rootCategoryId = $this->storeManager->getGroup($storeGroupId)->getRootCategoryId();
-            // set recursion level high to ensure all categories are returned
-            $categoryNodes = $this->categoryResource->getCategories($rootCategoryId, 100, false, true);
-            $this->storeCategories[$storeId] = array_merge([$rootCategoryId], $categoryNodes->getAllIds());
+            $collection = $this->relevantCategory->getCollection($storeId);
+            $this->storeCategories[$storeId] = $collection->getAllIds();
         }
 
         $result = [];

--- a/Model/RelevantCategory.php
+++ b/Model/RelevantCategory.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\ResourceModel\Category\Collection;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
 use Aligent\FredhopperIndexer\Helper\GeneralConfig;
 use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 
 class RelevantCategory
 {
@@ -17,23 +18,26 @@ class RelevantCategory
     private CategoryRepositoryInterface $categoryRepository;
     private CollectionFactory $categoryCollectionFactory;
     private GeneralConfig $config;
+    private StoreManagerInterface $storeManager;
 
     private array $ancestorCategories;
 
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
         CollectionFactory $categoryCollectionFactory,
-        GeneralConfig $config
+        GeneralConfig $config,
+        StoreManagerInterface $storeManager
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->config = $config;
+        $this->storeManager = $storeManager;
     }
 
     /**
      * @return int[]
      */
-    public function getAncestorCategoryIds(): array
+    private function getAncestorCategoryIds(): array
     {
         if (isset($this->ancestorCategories)) {
             return $this->ancestorCategories;
@@ -56,21 +60,34 @@ class RelevantCategory
     }
 
     /**
+     * @param int|null $storeId
      * @return Collection
      */
-    public function getCollection(): Collection
+    public function getCollection(?int $storeId = null): Collection
     {
         $ancestorIds = $this->getAncestorCategoryIds();
 
-        $categories = $this->categoryCollectionFactory->create();
-        $categories->setStoreId(Store::DEFAULT_STORE_ID);
-        $categories->addAttributeToFilter(CategoryInterface::KEY_IS_ACTIVE, 1);
-        if (count($ancestorIds) > 0) {
-            $categories->addAttributeToFilter('entity_id', ['nin' => $ancestorIds]);
+        $categoryIds = [];
+        // loop through each store as is_active may be set at store level
+        foreach ($this->storeManager->getStores() as $store) {
+            // if store id is given, then skip other stores
+            if ($storeId !== null && $storeId !== (int)$store->getId()) {
+                continue;
+            }
+            if (in_array($store->getId(), $this->config->getExcludedStores())) {
+                continue;
+            }
+            $categories = $this->categoryCollectionFactory->create();
+            $categories->setStoreId((int)$store->getId());
+            $categories->addAttributeToFilter(CategoryInterface::KEY_IS_ACTIVE, 1);
+            if (count($ancestorIds) > 0) {
+                $categories->addAttributeToFilter('entity_id', ['nin' => $ancestorIds]);
+            }
+            $categoryIds[] = $categories->getAllIds();
         }
 
         // ensure the root category is in the collection
-        $categoryIds = array_merge($categories->getAllIds(),[$this->config->getRootCategoryId()]);
+        $categoryIds = array_merge([$this->config->getRootCategoryId()], ...$categoryIds);
         $categories = $this->categoryCollectionFactory->create();
         $categories->addIdFilter($categoryIds);
         $categories->addNameToResult();

--- a/Model/RelevantCategory.php
+++ b/Model/RelevantCategory.php
@@ -71,6 +71,7 @@ class RelevantCategory
         $ancestorIds = $this->getAncestorCategoryIds();
 
         $categoryIds = [];
+        $rootCategories = [$this->config->getRootCategoryId()];
         // loop through each store as is_active may be set at store level
         foreach ($this->storeManager->getStores() as $store) {
             // if store id is given, then skip other stores
@@ -82,6 +83,8 @@ class RelevantCategory
             }
             $storeGroupId = $store->getStoreGroupId();
             $rootCategoryForStore = $this->storeManager->getGroup($storeGroupId)->getRootCategoryId();
+            $rootCategories[] = $rootCategoryForStore;
+
             /** @var CategoryCollection $categories */
             $categories = $this->categoryCollectionFactory->create();
             $categories->setStoreId((int)$store->getId());
@@ -95,7 +98,7 @@ class RelevantCategory
         }
 
         // ensure the root category is in the collection
-        $categoryIds = array_merge([$this->config->getRootCategoryId()], ...$categoryIds);
+        $categoryIds = array_merge($rootCategories, ...$categoryIds);
         $categories = $this->categoryCollectionFactory->create();
         $categories->addIdFilter($categoryIds);
         $categories->addNameToResult();


### PR DESCRIPTION
It turns out that `\Magento\Catalog\Model\ResourceModel\Category->getCategories` applies a filter on `include_in_menu`, which shouldn't really be a requirement.
So, instead, to get the relevant categories, we can filter by the root category of each store and just `is_active`. If we don't supply a store ID, this will return the allowed categories for all stores (for use when sending meta information about categories).