### PR TITLE
Ensure that an integer is always returned by getVersionId

### DIFF
--- a/src/export/Model/Data/Export.php
+++ b/src/export/Model/Data/Export.php
@@ -317,7 +317,7 @@ class Export extends AbstractModel implements ExportInterface
      */
     public function getVersionId(): int
     {
-        return $this->getData(self::FIELD_VERSION_ID);
+        return (int)$this->getData(self::FIELD_VERSION_ID);
     }
 
     /**

--- a/src/export/Model/Data/Files/GenerateVariantFiles.php
+++ b/src/export/Model/Data/Files/GenerateVariantFiles.php
@@ -65,7 +65,7 @@ class GenerateVariantFiles
             $isIncremental
         );
         $filename = $directory . DIRECTORY_SEPARATOR . self::VARIANT_FILE_PREFIX . $fileNumber . '.json';
-        $content = ['products' => $productData];
+        $content = ['variants' => $productData];
         $this->file->filePutContents($filename, $this->json->serialize($content));
         return $filename;
     }


### PR DESCRIPTION
As per the title - prevent type errors