### PR TITLE
Fix/suggest export

### DIFF
--- a/src/export/Model/Data/Suggest/SearchTermsFileGenerator.php
+++ b/src/export/Model/Data/Suggest/SearchTermsFileGenerator.php
@@ -37,9 +37,6 @@ class SearchTermsFileGenerator implements FileGeneratorInterface
     {
         $defaultLocale = $this->generalConfig->getDefaultLocale();
         $searchTerms = $this->getSearchTerms();
-        if (empty($searchTerms)) {
-            return '';
-        }
 
         $filename = $directory . DIRECTORY_SEPARATOR .
             ($this->isBlacklist ? self::BLACKLIST_FILENAME : self::WHITELIST_FILENAME);

--- a/src/export/Model/GenerateSuggestExport.php
+++ b/src/export/Model/GenerateSuggestExport.php
@@ -55,7 +55,16 @@ class GenerateSuggestExport
             // create all required files
             $files = [];
             foreach ($this->fileGenerators as $fileGenerator) {
-                $files[] = $fileGenerator->generateFile($directory);
+                $file = $fileGenerator->generateFile($directory);
+                if (!empty($file)) {
+                    $files[] = $fileGenerator->generateFile($directory);
+                }
+            }
+
+            // only create the zip file and export entity if there are files to include
+            if (empty($files)) {
+                $this->logger->info(__METHOD__ . ': No files to export');
+                return;
             }
 
             // create zip file


### PR DESCRIPTION
We still want to send the blacklist and whitelist csv files, even if there are no search terms defined.
This fixes a bug where an empty filename was returned and the attempt to add it to the zip file produced an error.