### PR TITLE
Feature/export improvements

### DIFF
--- a/src/export/Controller/Adminhtml/Exports/Data.php
+++ b/src/export/Controller/Adminhtml/Exports/Data.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\FredhopperExport\Controller\Adminhtml\Exports;
+
+use Aligent\FredhopperExport\Api\Data\ExportInterface;
+use Aligent\FredhopperExport\Model\Data\Export;
+use Aligent\FredhopperExport\Model\Data\ExportFactory;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export as ExportResource;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Filesystem\Io\File as Filesystem;
+use Psr\Log\LoggerInterface;
+
+class Data extends Action
+{
+
+    public const string ADMIN_RESOURCE = 'Aligent_FredhopperExport::manage';
+
+    /**
+     * @param Context $context
+     * @param ExportFactory $exportFactory
+     * @param ExportResource $exportResource
+     * @param FileFactory $fileFactory
+     * @param LoggerInterface $logger
+     * @param Filesystem $filesystem
+     */
+    public function __construct(
+        readonly Context $context,
+        private readonly ExportFactory $exportFactory,
+        private readonly ExportResource $exportResource,
+        private readonly FileFactory $fileFactory,
+        private readonly LoggerInterface $logger,
+        private readonly Filesystem $filesystem
+    ) {
+        parent::__construct($context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(): ResponseInterface
+    {
+        $exportId = (int)$this->getRequest()->getParam('id');
+        if (empty($exportId)) {
+            $this->getMessageManager()->addErrorMessage(__('Export ID is required.'));
+            $this->_redirect('*/*/index');
+            return $this->_response;
+        }
+        $isZip = (bool)$this->getRequest()->getParam('zip');
+        /** @var Export $export */
+        $export = $this->exportFactory->create();
+        $this->exportResource->load($export, $exportId);
+        if ($export->isEmpty()) {
+            $this->getMessageManager()->addErrorMessage(__('Could not load export data.'));
+            $this->_redirect('*/*/index');
+            return $this->_response;
+        }
+        $directory = $export->getDirectory();
+        $filename = match ($export->getExportType()) {
+            ExportInterface::EXPORT_TYPE_INCREMENTAL => ExportInterface::ZIP_FILENAME_INCREMENTAL,
+            ExportInterface::EXPORT_TYPE_FULL => ExportInterface::ZIP_FILENAME_FULL,
+            ExportInterface::EXPORT_TYPE_SUGGEST => ExportInterface::ZIP_FILENAME_SUGGEST,
+            default => ''
+        };
+        if (empty($filename)) {
+            $this->getMessageManager()->addErrorMessage(__('Could not download data file.'));
+            $this->_redirect('*/*/index');
+            return $this->_response;
+        }
+
+        $filename = $directory . DIRECTORY_SEPARATOR . $filename;
+        $name = $this->filesystem->getPathInfo($filename)['basename'] ?? $filename;
+        try {
+            return $this->fileFactory->create(
+                $name,
+                [
+                    'type' => 'filename',
+                    'value' => $filename,
+                    'rm' => false
+                ],
+                DirectoryList::VAR_DIR,
+                'application/zip'
+            );
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            $this->getMessageManager()->addErrorMessage(__('Could not download data file.'));
+            $this->_redirect('*/*/index');
+            return $this->_response;
+        }
+    }
+}

--- a/src/export/Cron/Generate/Suggest.php
+++ b/src/export/Cron/Generate/Suggest.php
@@ -7,11 +7,19 @@ use Aligent\FredhopperExport\Model\GenerateSuggestExport;
 
 class Suggest
 {
+    /**
+     * @param GenerateSuggestExport $generateSuggestExport
+     */
     public function __construct(
         private readonly GenerateSuggestExport $generateSuggestExport
     ) {
     }
 
+    /**
+     * Generate a suggest export
+     *
+     * @return void
+     */
     public function execute(): void
     {
         $this->generateSuggestExport->execute();

--- a/src/export/Cron/Trigger.php
+++ b/src/export/Cron/Trigger.php
@@ -5,6 +5,7 @@ namespace Aligent\FredhopperExport\Cron;
 
 use Aligent\FredhopperExport\Api\Data\ExportInterface;
 use Aligent\FredhopperExport\Model\Data\Export;
+use Aligent\FredhopperExport\Model\GetExportIsInProgress;
 use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\Collection;
 use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\CollectionFactory;
 use Aligent\FredhopperExport\Model\TriggerDataLoad;
@@ -14,10 +15,12 @@ class Trigger
     /**
      * @param CollectionFactory $exportCollectionFactory
      * @param TriggerDataLoad $triggerDataLoad
+     * @param GetExportIsInProgress $getExportIsInProgress
      */
     public function __construct(
         private readonly CollectionFactory $exportCollectionFactory,
-        private readonly TriggerDataLoad $triggerDataLoad
+        private readonly TriggerDataLoad $triggerDataLoad,
+        private readonly GetExportIsInProgress $getExportIsInProgress
     ) {
     }
 
@@ -28,6 +31,10 @@ class Trigger
      */
     public function execute(): void
     {
+        // don't trigger if an export has already been triggered
+        if ($this->getExportIsInProgress->execute(true)) {
+            return;
+        }
         /** @var Collection $collection */
         $collection = $this->exportCollectionFactory->create();
         $collection->addFieldToFilter(ExportInterface::FIELD_STATUS, ExportInterface::STATUS_UPLOADED);

--- a/src/export/Cron/UpdateInvalidExports.php
+++ b/src/export/Cron/UpdateInvalidExports.php
@@ -3,27 +3,16 @@
 declare(strict_types=1);
 namespace Aligent\FredhopperExport\Cron;
 
-use Aligent\FredhopperExport\Api\Data\ExportInterface;
-use Aligent\FredhopperExport\Model\Data\Export;
-use Aligent\FredhopperExport\Model\Data\GetCurrentExportedVersion;
-use Aligent\FredhopperExport\Model\ResourceModel\Data\Export as ExportResource;
-use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\Collection;
+use Aligent\FredhopperExport\Model\InvalidateExports;
 use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\CollectionFactory;
-use Psr\Log\LoggerInterface;
 
 class UpdateInvalidExports
 {
     /**
-     * @param CollectionFactory $collectionFactory
-     * @param GetCurrentExportedVersion $getCurrentExportedVersion
-     * @param ExportResource $exportResource
-     * @param LoggerInterface $logger
+     * @param InvalidateExports $invalidateExports
      */
     public function __construct(
-        private readonly CollectionFactory $collectionFactory,
-        private readonly GetCurrentExportedVersion $getCurrentExportedVersion,
-        private readonly ExportResource $exportResource,
-        private readonly LoggerInterface $logger
+        private readonly InvalidateExports $invalidateExports,
     ) {
     }
 
@@ -34,26 +23,6 @@ class UpdateInvalidExports
      */
     public function execute(): void
     {
-        $currentExportedVersion = $this->getCurrentExportedVersion->execute();
-
-        /** @var Collection $collection */
-        $collection = $this->collectionFactory->create();
-        // need to check pending and uploaded exports only
-        $collection->addFieldToFilter(ExportInterface::FIELD_STATUS, ExportInterface::STATUS_PENDING);
-        $collection->addFieldToFilter(ExportInterface::FIELD_EXPORT_TYPE, ExportInterface::EXPORT_TYPE_INCREMENTAL);
-        /** @var Export[] $exports */
-        $exports = $collection->getItems();
-        foreach ($exports as $export) {
-            // mark incremental update as invalid if a more recent export has been uploaded already
-            if ($currentExportedVersion > $export->getVersionId()) {
-                $export->setStatus(ExportInterface::STATUS_INVALID);
-                try {
-                    $this->exportResource->save($export);
-                } catch (\Exception $e) {
-                    $message = sprintf('Error updating status of export %i', $export->getExportId());
-                    $this->logger->error($message, ['exception' => $e]);
-                }
-            }
-        }
+        $this->invalidateExports->execute();
     }
 }

--- a/src/export/Cron/Upload.php
+++ b/src/export/Cron/Upload.php
@@ -5,6 +5,8 @@ namespace Aligent\FredhopperExport\Cron;
 
 use Aligent\FredhopperExport\Api\Data\ExportInterface;
 use Aligent\FredhopperExport\Model\Data\Export;
+use Aligent\FredhopperExport\Model\Data\GetCurrentExportedVersion;
+use Aligent\FredhopperExport\Model\GetExportIsInProgress;
 use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\Collection;
 use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\CollectionFactory;
 use Aligent\FredhopperExport\Model\UploadExport;
@@ -14,10 +16,14 @@ class Upload
     /**
      * @param CollectionFactory $collectionFactory
      * @param UploadExport $uploadExport
+     * @param GetExportIsInProgress $getExportIsInProgress
+     * @param GetCurrentExportedVersion $getCurrentExportedVersion
      */
     public function __construct(
         private readonly CollectionFactory $collectionFactory,
-        private readonly UploadExport $uploadExport
+        private readonly UploadExport $uploadExport,
+        private readonly GetExportIsInProgress $getExportIsInProgress,
+        private readonly GetCurrentExportedVersion $getCurrentExportedVersion
     ) {
     }
 
@@ -28,13 +34,26 @@ class Upload
      */
     public function execute(): void
     {
+        // don't upload any export when an export is in progress
+        if ($this->getExportIsInProgress->execute()) {
+            return;
+        }
         /** @var Collection $collection */
         $collection = $this->collectionFactory->create();
-        $collection->addFieldToFilter('status', ExportInterface::STATUS_PENDING);
-        /** @var Export[] $exports */
-        $exports = $collection->getItems();
-        foreach ($exports as $export) {
-            $this->uploadExport->execute($export);
+        $collection->addFieldToFilter(ExportInterface::FIELD_STATUS, ExportInterface::STATUS_PENDING);
+        // do not upload any export behind the current version
+        $currentVersion = $this->getCurrentExportedVersion->execute();
+        if ($currentVersion > 0) {
+            $collection->addFieldToFilter(ExportInterface::FIELD_VERSION_ID, ['gt' => $currentVersion]);
+        }
+        // order by the version number descending to get the latest export
+        $collection->setOrder(ExportInterface::FIELD_VERSION_ID);
+        // we only ever want to upload a single export. Trying to upload multiple at once could prove troublesome
+        /** @var ExportInterface $firstExport */
+        $firstExport = $collection->getFirstItem();
+        if (!$firstExport->isEmpty()) {
+            /** @var Export $export */
+            $this->uploadExport->execute($firstExport);
         }
     }
 }

--- a/src/export/Model/DownloadQualityReport.php
+++ b/src/export/Model/DownloadQualityReport.php
@@ -45,6 +45,7 @@ class DownloadQualityReport
             }
         } catch (FileSystemException $e) {
             $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return null;
         }
 
         $qualityReportData = $this->dataIntegrationClient->getDataQualityReport($triggerId, $isSummary);

--- a/src/export/Model/GenerateSuggestExport.php
+++ b/src/export/Model/GenerateSuggestExport.php
@@ -51,6 +51,7 @@ class GenerateSuggestExport
 
             // create directory
             $directory = $this->createDirectory->execute(ExportInterface::EXPORT_TYPE_SUGGEST);
+            $export->setDirectory($directory);
 
             // create all required files
             $files = [];
@@ -74,13 +75,13 @@ class GenerateSuggestExport
                 $files
             );
             if (!$zipCreated) {
-                throw new LocalizedException(__('Error while creating ZIP file.'));
+                throw new LocalizedException(__(__METHOD__ . ': Error while creating ZIP file.'));
             }
 
             // save export
             $this->exportResource->save($export);
         } catch (\Exception $e) {
-            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            $this->logger->error(__METHOD__ . ': ' . $e->getMessage(), ['exception' => $e]);
         }
     }
 }

--- a/src/export/Model/GetExportIsInProgress.php
+++ b/src/export/Model/GetExportIsInProgress.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\FredhopperExport\Model;
+
+use Aligent\FredhopperExport\Api\Data\ExportInterface;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\Collection;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\CollectionFactory;
+
+class GetExportIsInProgress
+{
+    private const array IN_PROGRESS_STATUSES = [
+        ExportInterface::STATUS_UPLOADED,
+        ExportInterface::STATUS_TRIGGERED
+    ];
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     */
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory
+    ) {
+    }
+
+    /**
+     * Check if there is already an export in uploaded/triggered status.
+     *
+     * If $triggeredOnly is true, only check for triggered status
+     *
+     * @param bool $triggeredOnly
+     * @return bool
+     */
+    public function execute(bool $triggeredOnly = false): bool
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $statusesToCheck = $triggeredOnly ? [ExportInterface::STATUS_TRIGGERED] : self::IN_PROGRESS_STATUSES;
+        $collection->addFieldToFilter('status', ['in' => self::IN_PROGRESS_STATUSES]);
+        return $collection->getSize() > 0;
+    }
+}

--- a/src/export/Model/InvalidateExports.php
+++ b/src/export/Model/InvalidateExports.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\FredhopperExport\Model;
+
+use Aligent\FredhopperExport\Api\Data\ExportInterface;
+use Aligent\FredhopperExport\Model\Data\Export;
+use Aligent\FredhopperExport\Model\Data\GetCurrentExportedVersion;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export as ExportResource;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\Collection;
+use Aligent\FredhopperExport\Model\ResourceModel\Data\Export\CollectionFactory;
+use Psr\Log\LoggerInterface;
+
+class InvalidateExports
+{
+    /**
+     * @param CollectionFactory $collectionFactory
+     * @param GetCurrentExportedVersion $getCurrentExportedVersion
+     * @param ExportResource $exportResource
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly GetCurrentExportedVersion $getCurrentExportedVersion,
+        private readonly ExportResource $exportResource,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Update the status of pending exports
+     *
+     * @return void
+     */
+    public function execute(): void
+    {
+        $currentExportedVersion = $this->getCurrentExportedVersion->execute();
+
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        // need to check pending and uploaded exports only
+        $collection->addFieldToFilter(ExportInterface::FIELD_STATUS, ExportInterface::STATUS_PENDING);
+        $collection->addFieldToFilter(ExportInterface::FIELD_EXPORT_TYPE, ExportInterface::EXPORT_TYPE_INCREMENTAL);
+        /** @var Export[] $exports */
+        $exports = $collection->getItems();
+        foreach ($exports as $export) {
+            // mark incremental update as invalid if a more recent export has been uploaded already
+            if ($currentExportedVersion > $export->getVersionId()) {
+                $export->setStatus(ExportInterface::STATUS_INVALID);
+                try {
+                    $this->exportResource->save($export);
+                } catch (\Exception $e) {
+                    $message = sprintf('Error updating status of export %i', $export->getExportId());
+                    $this->logger->error($message, ['exception' => $e]);
+                }
+            }
+        }
+    }
+}

--- a/src/export/Model/UpdateExportDataStatus.php
+++ b/src/export/Model/UpdateExportDataStatus.php
@@ -16,12 +16,14 @@ class UpdateExportDataStatus
      * @param DataIntegrationClient $dataIntegrationClient
      * @param ExportResource $exportResource
      * @param SetCurrentExport $setCurrentExport
+     * @param InvalidateExports $invalidateExports
      * @param LoggerInterface $logger
      */
     public function __construct(
         private readonly DataIntegrationClient $dataIntegrationClient,
         private readonly ExportResource $exportResource,
         private readonly SetCurrentExport $setCurrentExport,
+        private readonly InvalidateExports $invalidateExports,
         private readonly LoggerInterface $logger
     ) {
     }
@@ -68,6 +70,8 @@ class UpdateExportDataStatus
 
         if ($dataStatus === ExportInterface::DATA_STATUS_SUCCESS) {
             $this->setCurrentExport->execute($export->getExportId());
+            // invalidate any pending exports that have an earlier version than the current one
+            $this->invalidateExports->execute();
         }
     }
 }

--- a/src/export/Ui/Component/Listing/Column/Actions.php
+++ b/src/export/Ui/Component/Listing/Column/Actions.php
@@ -14,6 +14,7 @@ use Magento\Ui\Component\Listing\Columns\Column;
 class Actions extends Column
 {
     private const string URL_PATH_REPORT = 'fredhopper/exports/report';
+    private const string URL_PATH_DATA_FILE = 'fredhopper/exports/data';
 
     /**
      * @param ContextInterface $context
@@ -43,32 +44,44 @@ class Actions extends Column
             foreach ($dataSource['data']['items'] as &$item) {
                 if (isset($item[ExportInterface::FIELD_EXPORT_ID])) {
                     $exportId = (int)$item[ExportInterface::FIELD_EXPORT_ID];
+                    // give link to download export zip file
+                    $actions = [
+                        'download_data' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                self::URL_PATH_DATA_FILE,
+                                [
+                                    'id' => $item[ExportInterface::FIELD_EXPORT_ID]
+                                ]
+                            ),
+                            'label' => __('Download Data File'),
+                            'target' => '_blank'
+                        ]
+                    ];
                     // if the export is already complete, we can download a quality report
                     if ($this->canDownloadReport($exportId)) {
-                        $item[$this->getData('name')] = [
-                            'download' => [
-                                'href' => $this->urlBuilder->getUrl(
-                                    self::URL_PATH_REPORT,
-                                    [
-                                        'id' => $item[ExportInterface::FIELD_EXPORT_ID]
-                                    ]
-                                ),
-                                'label' => __('Download Quality Report'),
-                                'target' => '_blank',
-                            ],
-                            'download_zip' => [
-                                'href' => $this->urlBuilder->getUrl(
-                                    self::URL_PATH_REPORT,
-                                    [
-                                        'id' => $item[ExportInterface::FIELD_EXPORT_ID],
-                                        'zip' => true
-                                    ]
-                                ),
-                                'label' => __('Download ZIP Report'),
-                                'target' => '_blank',
-                            ]
+                        $actions['download_report'] = [
+                            'href' => $this->urlBuilder->getUrl(
+                                self::URL_PATH_REPORT,
+                                [
+                                    'id' => $item[ExportInterface::FIELD_EXPORT_ID]
+                                ]
+                            ),
+                            'label' => __('Download Quality Report'),
+                            'target' => '_blank'
+                        ];
+                        $actions['download_report_zip'] = [
+                            'href' => $this->urlBuilder->getUrl(
+                                self::URL_PATH_REPORT,
+                                [
+                                    'id' => $item[ExportInterface::FIELD_EXPORT_ID],
+                                    'zip' => true
+                                ]
+                            ),
+                            'label' => __('Download ZIP Report'),
+                            'target' => '_blank',
                         ];
                     }
+                    $item[$this->getData('name')] = $actions;
                 }
             }
         }
@@ -99,5 +112,4 @@ class Actions extends Column
         }
         return true;
     }
-
 }

--- a/src/export/etc/crontab.xml
+++ b/src/export/etc/crontab.xml
@@ -15,19 +15,19 @@
         </job>
         <job name="fredhopper_upload_export"
              instance="Aligent\FredhopperExport\Cron\Upload" method="execute">
-            <schedule>*/10 * * * *</schedule>
+            <schedule>*/1 * * * *</schedule>
         </job>
         <job name="fredhopper_trigger_export"
              instance="Aligent\FredhopperExport\Cron\Trigger" method="execute">
-            <schedule>*/10 * * * *</schedule>
+            <schedule>*/1 * * * *</schedule>
         </job>
         <job name="fredhopper_invalidate_exports"
              instance="Aligent\FredhopperExport\Cron\UpdateInvalidExports" method="execute">
-            <schedule>*/5 * * * *</schedule>
+            <schedule>*/1 * * * *</schedule>
         </job>
         <job name="fredhopper_update_data_status"
              instance="Aligent\FredhopperExport\Cron\UpdateTriggeredExports" method="execute">
-            <schedule>*/5 * * * *</schedule>
+            <schedule>*/1 * * * *</schedule>
         </job>
         <job name="fredhopper_clean_exports"
              instance="Aligent\FredhopperExport\Cron\Clean" method="execute">


### PR DESCRIPTION
A couple of bug fixes, and some general quality-of-life improvements for the export functionality:

# Bug fixes
 - Fix a bug with the suggest export, which was not setting the directory
 - Return early from downloading the quality report in case of an error

# Improvements
 - Give ability to download the generated data file
 - Increase the frequency of a number of cron jobs
   - This is to reduce the time between export creation, upload and triggering to lower the chances of conflicts between multiple exports
 - Restrict the upload cron job to a single export, instead of all pending ones.
   - Also order by the version id (descending), so we're always uploading the latest export
 - Prevent uploading or triggering an export if there is already another export in the process of being loaded
 - Move invalidation of exports to a service class
   - Also call this class after changing the current version (indicating which export is currently loaded in FH)