### PR TITLE
Invalidate both full and incremental exports in pending or uploaded status

### DIFF
--- a/src/export/Model/InvalidateExports.php
+++ b/src/export/Model/InvalidateExports.php
@@ -39,8 +39,14 @@ class InvalidateExports
         /** @var Collection $collection */
         $collection = $this->collectionFactory->create();
         // need to check pending and uploaded exports only
-        $collection->addFieldToFilter(ExportInterface::FIELD_STATUS, ExportInterface::STATUS_PENDING);
-        $collection->addFieldToFilter(ExportInterface::FIELD_EXPORT_TYPE, ExportInterface::EXPORT_TYPE_INCREMENTAL);
+        $collection->addFieldToFilter(
+            ExportInterface::FIELD_STATUS,
+            ['in' => [ExportInterface::STATUS_PENDING, ExportInterface::STATUS_UPLOADED]]
+        );
+        $collection->addFieldToFilter(
+            ExportInterface::FIELD_EXPORT_TYPE,
+            ['in' => [ExportInterface::EXPORT_TYPE_INCREMENTAL, ExportInterface::EXPORT_TYPE_FULL]]
+        );
         /** @var Export[] $exports */
         $exports = $collection->getItems();
         foreach ($exports as $export) {


### PR DESCRIPTION
Initially, it was thought that a full export would never be "invalid", which is true in some sense, but we don't really want to be automatically uploading out-of-date data.
This change will set both full and incremental exports to invalid if their version number is earlier than the current uploaded version.
It also allows exports that have already been uploaded, but not triggered, to be invalidated.