### PR TITLE
Change upload logic so that exports are allowed at the current version

### DIFF
--- a/src/export/Cron/Upload.php
+++ b/src/export/Cron/Upload.php
@@ -44,7 +44,7 @@ class Upload
         // do not upload any export behind the current version
         $currentVersion = $this->getCurrentExportedVersion->execute();
         if ($currentVersion > 0) {
-            $collection->addFieldToFilter(ExportInterface::FIELD_VERSION_ID, ['gte' => $currentVersion]);
+            $collection->addFieldToFilter(ExportInterface::FIELD_VERSION_ID, ['gteq' => $currentVersion]);
         }
         // order by the version number descending to get the latest export
         $collection->setOrder(ExportInterface::FIELD_VERSION_ID);

--- a/src/export/Cron/Upload.php
+++ b/src/export/Cron/Upload.php
@@ -44,7 +44,7 @@ class Upload
         // do not upload any export behind the current version
         $currentVersion = $this->getCurrentExportedVersion->execute();
         if ($currentVersion > 0) {
-            $collection->addFieldToFilter(ExportInterface::FIELD_VERSION_ID, ['gt' => $currentVersion]);
+            $collection->addFieldToFilter(ExportInterface::FIELD_VERSION_ID, ['gte' => $currentVersion]);
         }
         // order by the version number descending to get the latest export
         $collection->setOrder(ExportInterface::FIELD_VERSION_ID);


### PR DESCRIPTION
It's possible for there to be metadata changes (e.g. category names, attribute types) that don't actually result in a new version of indexed product data, but do have an impact within FH. As such, we need to allow exports where the version is still the same as the current version in use.

This change would also allow incremental exports with the same version to be uploaded, however this should be fine because:
 - Incremental updates are not created unless something has actually changed
 - If a new version was created before the previous export had finished being loaded into FH (so the version was the same), it would either just be product updates (to the same values), or it would have invalid additions/deletions and would be rejected anyway.